### PR TITLE
(release) v1.2.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,4 @@ S3_ENDPOINT=https://<bucket_name>.s3.amazonaws.com # for example in us-east-1
 PORT=9000
 MONGODB_URL=mongodb://root:MheCk6sSKB1m4xKNw5I@127.0.0.1/cb_sau_db?authSource=admin
 SYSTEM_KEY=
+MONGODB_URL_TESTS=mongodb://root:MheCk6sSKB1m4xKNw5I@127.0.0.1:27018/cb_sau_db?authSource=admin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
-## v1.0.1
+## v1.1.0
 
 ### Important Notes
 
 - **Important**: After first creating channel, field `channel_name` is required.
+
+Added a set of functionalities for the operation and support of deployment channels.
+Many checks have been added for a more accurate and expected behavior of the application.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## v1.2.0
+
+### Important Notes
+
+- **Important**: Changed the method of creating an admin user. Now, after creation, the web server starts and operates in normal mode, so it is recommended to use creation in complex with migration.
+
+### Maintenance
+
+- Added `MONGODB_URL_TESTS` to `.env.example`
+
+### Docker
+- Added `mongoDB` for testing to `docker compose` configuration.
+
+### Features
+
+- :tada: Implemented e2e tests
+    - TestHealthCheck
+    - TestLogin
+    - TestUploadApp
+    - TestUploadDuplicateApp (expected result from api "failed")
+    - TestDeleteApp
+    - TestChannelCreateNightly
+    - TestChannelCreateStable
+    - TestUploadAppWithoutChannel (expected result from api "failed")
+    - TestMultipleUploadWithChannels
+    - TestSearchApp
+    - TestCheckVersionLatestVersion
+    - TestMultipleDelete
+    - TestDeleteNightlyChannel
+    - TestDeleteStableChannel
+
 ## v1.1.0
 
 ### Important Notes

--- a/README.md
+++ b/README.md
@@ -37,22 +37,18 @@ To use the auto updater service, follow these steps:
 go build -o sau sau.go
 ```
 
-2. Start the auto updater service with migrations:
+2. Start the auto updater service with migrations and create Administration user:
 ```
-./sau --migration
+./sau --migration --username=admin --password=password
 ```
 Note: To rollback your migrations run:
 ```
 ./sau --migration --rollback
 ```
-3. Create Administration user:
-```
-./sau --username=admin --password=password
-```
 
-4. Upload your application to S3 and set the version number in Admin Api.
+3. Upload your application to S3 and set the version number in Admin Api.
 
-5. In your client application, make a POST request to the auto updater service API, passing the current version number as a query parameter:
+4. In your client application, make a POST request to the auto updater service API, passing the current version number as a query parameter:
 ```
 http://localhost:9000/checkVersion?app_name=myapp&version=4.1.5
 ```
@@ -68,7 +64,36 @@ The auto updater service will return a JSON response with the following structur
 
 If an update is available, the update_available field will be true, and the update_url field will contain a link to the updated application.
 
-6. In your client application, show an alert to the user indicating that an update is available and provide a link to download the updated application.
+5. In your client application, show an alert to the user indicating that an update is available and provide a link to download the updated application.
+
+## Testing
+Run e2e tests:
+```
+go test
+```
+
+**Test Descriptions**
+
+To successfully run the tests and have them pass, you need to populate the .env file.
+
+The tests verify the implemented API using a test database and an existing S3 bucket.
+
+**List of Tests**
+
+    - TestHealthCheck
+    - TestLogin
+    - TestUploadApp
+    - TestUploadDuplicateApp (expected result from API "failed")
+    - TestDeleteApp
+    - TestChannelCreateNightly
+    - TestChannelCreateStable
+    - TestUploadAppWithoutChannel (expected result from API "failed")
+    - TestMultipleUploadWithChannels
+    - TestSearchApp
+    - TestCheckVersionLatestVersion
+    - TestMultipleDelete
+    - TestDeleteNightlyChannel
+    - TestDeleteStableChannel
 
 ## Create new migrations
 Install migrate tool [here](https://github.com/golang-migrate/migrate/blob/master/cmd/migrate/README.md).

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,5 +13,19 @@ services:
     ports:
       - "27017:27017"
 
+  mongo_tests:
+    image: mongo:4.4
+    container_name: server_mongo_database_tests
+    restart: always
+    volumes:
+      - data-tests:/data/db
+    environment:
+      - MONGO_INITDB_DATABASE=cb_sau_db
+      - MONGO_INITDB_ROOT_USERNAME=root
+      - MONGO_INITDB_ROOT_PASSWORD=MheCk6sSKB1m4xKNw5I
+    ports:
+      - "27018:27017"
+
 volumes:
   data:
+  data-tests:

--- a/go.mod
+++ b/go.mod
@@ -24,12 +24,14 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.18.5 // indirect
 	github.com/aws/smithy-go v1.13.5 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/klauspost/compress v1.15.15 // indirect
 	github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.1.1 // indirect
 	github.com/xdg-go/stringprep v1.0.3 // indirect
@@ -65,6 +67,7 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/testify v1.8.4
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/ugorji/go/codec v1.2.8 // indirect
 	go.mongodb.org/mongo-driver v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -1124,6 +1124,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/subosito/gotenv v1.4.1 h1:jyEFiXpy21Wm81FBN71l9VoMMV8H8jG+qIK3GCpY6Qs=
 github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=

--- a/mongod/adapter.go
+++ b/mongod/adapter.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -41,7 +40,6 @@ func ConnectToDatabase(mongoUrl string, flags map[string]interface{}) (*mongo.Cl
 			log.Fatal(err)
 		} else {
 			log.Println("Successfully created admin user with name: ", flags["user_name"].(string))
-			os.Exit(0)
 		}
 	}
 	return client, uriOptions

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,768 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"SAU/mongod"
+	db "SAU/mongod"
+	"SAU/server/handler"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/connstring"
+)
+
+var (
+	client        *mongo.Client
+	appDB         db.AppRepository
+	mongoDatabase *mongo.Database
+	configDB      connstring.ConnString
+	s3Endpoint    string
+)
+
+func TestMain(m *testing.M) {
+	// Set up resources before running tests
+	setup()
+	// Run the tests
+	code := m.Run()
+	teardown()
+	os.Exit(code)
+}
+
+func setup() {
+	viper.SetConfigType("env")
+	viper.SetConfigName(".env")
+	// set the configuration file path
+	viper.AddConfigPath(".")
+	// read in the configuration file
+	if err := viper.ReadInConfig(); err != nil {
+		panic(err)
+	}
+	// Create a single database connection
+	flagMap := map[string]interface{}{
+		"migration":     true,
+		"rollback":      false,
+		"user_name":     "admin",
+		"user_password": "password",
+	}
+	s3Endpoint = viper.GetString("S3_ENDPOINT")
+	client, configDB = mongod.ConnectToDatabase(viper.GetString("MONGODB_URL_TESTS"), flagMap)
+	appDB = mongod.NewAppRepository(&configDB, client)
+	mongoDatabase = client.Database(configDB.Database)
+
+}
+
+func teardown() {
+	adminsCollection := mongoDatabase.Collection("admins")
+	filter := bson.M{"username": "admin"}
+
+	// Delete the admin user from the collection
+	_, err := adminsCollection.DeleteOne(context.TODO(), filter)
+	if err != nil {
+		logrus.Errorf("Failed to remove admin user: %v", err)
+	}
+	log.Println("Successfully removed admin user.")
+	client.Disconnect(context.Background())
+	log.Println("MongoDB is disconnected.")
+}
+
+func TestHealthCheck(t *testing.T) {
+
+	router := gin.Default()
+	w := httptest.NewRecorder()
+
+	handler := handler.NewAppHandler(client, appDB, mongoDatabase)
+	router.GET("/health", func(c *gin.Context) {
+		handler.HealthCheck(c)
+	})
+
+	req, _ := http.NewRequest("GET", "/health", nil)
+
+	// Serve the request using the Gin router.
+	router.ServeHTTP(w, req)
+
+	// Check the response status code.
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Check the response body.
+	expected := `{"status":"healthy"}`
+	assert.Equal(t, expected, w.Body.String())
+}
+
+var authToken string
+
+func TestLogin(t *testing.T) {
+
+	router := gin.Default()
+	w := httptest.NewRecorder()
+
+	handler := handler.NewAppHandler(client, appDB, mongoDatabase)
+	router.POST("/login", func(c *gin.Context) {
+		handler.Login(c)
+	})
+
+	// Create a JSON payload for the request
+	payload := `{"username": "admin", "password": "password"}`
+
+	req, err := http.NewRequest("POST", "/login", strings.NewReader(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	// Serve the request using the Gin router.
+	router.ServeHTTP(w, req)
+
+	// Check the response status code.
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Parse the JSON response body to extract the token.
+	var response map[string]interface{}
+	err = json.Unmarshal(w.Body.Bytes(), &response)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that the "token" key exists in the response.
+	token, tokenExists := response["token"]
+	assert.True(t, tokenExists)
+
+	authToken = token.(string)
+
+	// Check that the authToken variable has been set (assuming authToken is a global variable).
+	assert.NotEmpty(t, authToken)
+}
+
+var uploadedFirstApp string
+
+func TestUpload(t *testing.T) {
+
+	router := gin.Default()
+	w := httptest.NewRecorder()
+
+	// Define the route for the upload endpoint.
+	handler := handler.NewAppHandler(client, appDB, mongoDatabase)
+	router.POST("/upload", func(c *gin.Context) {
+		handler.UploadApp(c)
+	})
+
+	// Create a file to upload (you can replace this with a test file path).
+	filePath := "LICENSE"
+	file, err := os.Open(filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	// Create a multipart/form-data request with the file.
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("file", filepath.Base(filePath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = io.Copy(part, file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer.Close()
+
+	// Create a POST request for the upload endpoint.
+	req, err := http.NewRequest("POST", "/upload?app_name=testapp&version=0.0.1", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set the Content-Type header for multipart/form-data.
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	// Set the Authorization header.
+	req.Header.Set("Authorization", "Bearer "+authToken)
+	// Serve the request using the Gin router.
+	router.ServeHTTP(w, req)
+
+	// Check the response status code.
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]interface{}
+	err = json.Unmarshal(w.Body.Bytes(), &response)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Check that the "token" key exists in the response.
+	id, idExists := response["uploadResult.Uploaded"]
+	assert.True(t, idExists)
+
+	uploadedFirstApp = id.(string)
+	assert.True(t, idExists)
+	assert.NotEmpty(t, uploadedFirstApp)
+}
+
+func TestUploadDuplicateApp(t *testing.T) {
+
+	router := gin.Default()
+	w := httptest.NewRecorder()
+
+	// Define the route for the upload endpoint.
+	handler := handler.NewAppHandler(client, appDB, mongoDatabase)
+	router.POST("/upload", func(c *gin.Context) {
+		handler.UploadApp(c)
+	})
+
+	// Create a file to upload (you can replace this with a test file path).
+	filePath := "LICENSE"
+	file, err := os.Open(filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	// Create a multipart/form-data request with the file.
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("file", filepath.Base(filePath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = io.Copy(part, file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer.Close()
+
+	// Create a POST request for the upload endpoint.
+	req, err := http.NewRequest("POST", "/upload?app_name=testapp&version=0.0.1", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set the Content-Type header for multipart/form-data.
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	// Set the Authorization header.
+	req.Header.Set("Authorization", "Bearer "+authToken)
+	// Serve the request using the Gin router.
+	router.ServeHTTP(w, req)
+
+	// Check the response status code (expecting 500).
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+
+	// Check the response body for the desired error message.
+	expectedErrorMessage := `{"error":"app with this name and version already exists"}`
+	assert.Equal(t, expectedErrorMessage, w.Body.String())
+}
+
+func TestDeleteApp(t *testing.T) {
+
+	router := gin.Default()
+	w := httptest.NewRecorder()
+
+	// Define the route for the upload endpoint.
+	handler := handler.NewAppHandler(client, appDB, mongoDatabase)
+	router.DELETE("/deleteApp", func(c *gin.Context) {
+		handler.DeleteApp(c)
+	})
+
+	// Create a POST request for the upload endpoint.
+	req, err := http.NewRequest("DELETE", "/deleteApp?id="+uploadedFirstApp, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set the Authorization header.
+	req.Header.Set("Authorization", "Bearer "+authToken)
+	// Serve the request using the Gin router.
+	router.ServeHTTP(w, req)
+
+	// Check the response status code.
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	expected := `{"deleteAppResult.DeletedCount":1}`
+	assert.Equal(t, expected, w.Body.String())
+}
+
+var idNightlyChannel string
+var idStableChannel string
+
+func TestChannelCreateNightly(t *testing.T) {
+
+	router := gin.Default()
+	w := httptest.NewRecorder()
+
+	handler := handler.NewAppHandler(client, appDB, mongoDatabase)
+	router.POST("/createChannel", func(c *gin.Context) {
+		handler.CreateChannel(c)
+	})
+
+	req, err := http.NewRequest("POST", "/createChannel?channel_name=nightly", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Serve the request using the Gin router.
+	router.ServeHTTP(w, req)
+
+	// Check the response status code.
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]interface{}
+	err = json.Unmarshal(w.Body.Bytes(), &response)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Check that the "token" key exists in the response.
+	id, idExists := response["createChannelResult.Created"]
+	assert.True(t, idExists)
+	idNightlyChannel = id.(string)
+	assert.True(t, idExists)
+	assert.NotEmpty(t, idNightlyChannel)
+}
+
+func TestChannelCreateStable(t *testing.T) {
+
+	router := gin.Default()
+	w := httptest.NewRecorder()
+
+	handler := handler.NewAppHandler(client, appDB, mongoDatabase)
+	router.POST("/createChannel", func(c *gin.Context) {
+		handler.CreateChannel(c)
+	})
+
+	req, err := http.NewRequest("POST", "/createChannel?channel_name=stable", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Serve the request using the Gin router.
+	router.ServeHTTP(w, req)
+
+	// Check the response status code.
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]interface{}
+	err = json.Unmarshal(w.Body.Bytes(), &response)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Check that the "token" key exists in the response.
+	id, idExists := response["createChannelResult.Created"]
+	assert.True(t, idExists)
+	idStableChannel = id.(string)
+	assert.True(t, idExists)
+	assert.NotEmpty(t, idStableChannel)
+}
+
+func TestUploadAppWithoutChannel(t *testing.T) {
+
+	router := gin.Default()
+	w := httptest.NewRecorder()
+
+	// Define the route for the upload endpoint.
+	handler := handler.NewAppHandler(client, appDB, mongoDatabase)
+	router.POST("/upload", func(c *gin.Context) {
+		handler.UploadApp(c)
+	})
+
+	// Create a file to upload (you can replace this with a test file path).
+	filePath := "LICENSE"
+	file, err := os.Open(filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	// Create a multipart/form-data request with the file.
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("file", filepath.Base(filePath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = io.Copy(part, file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer.Close()
+
+	// Create a POST request for the upload endpoint.
+	req, err := http.NewRequest("POST", "/upload?app_name=testapp&version=0.0.1", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set the Content-Type header for multipart/form-data.
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	// Set the Authorization header.
+	req.Header.Set("Authorization", "Bearer "+authToken)
+	// Serve the request using the Gin router.
+	router.ServeHTTP(w, req)
+
+	// Check the response status code (expecting 500).
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	// Check the response body for the desired error message.
+	expectedErrorMessage := `{"error":"you have a created channels, setting channel_name is required"}`
+	assert.Equal(t, expectedErrorMessage, w.Body.String())
+}
+
+var uploadedAppIDs []string
+
+func TestMultipleUpload(t *testing.T) {
+
+	router := gin.Default()
+
+	// Define the route for the upload endpoint.
+	handler := handler.NewAppHandler(client, appDB, mongoDatabase)
+	router.POST("/upload", func(c *gin.Context) {
+		handler.UploadApp(c)
+	})
+
+	// Create a file to upload (you can replace this with a test file path).
+	filePath := "LICENSE"
+	file, err := os.Open(filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	combinations := []struct {
+		AppVersion  string
+		ChannelName string
+	}{
+		{"0.0.1", "nightly"},
+		{"0.0.2", "nightly"},
+		{"0.0.3", "nightly"},
+		{"0.0.4", "stable"},
+		{"0.0.5", "stable"},
+	}
+
+	// Iterate through the combinations and upload the file for each combination.
+	for _, combo := range combinations {
+		w := httptest.NewRecorder()
+		// Reset the request body for each iteration.
+		body := &bytes.Buffer{}
+		writer := multipart.NewWriter(body)
+		part, err := writer.CreateFormFile("file", filepath.Base(filePath))
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = io.Copy(part, file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		writer.Close()
+		// Create a POST request for the upload endpoint with the current combination.
+		req, err := http.NewRequest("POST", fmt.Sprintf("/upload?app_name=testapp&version=%s&channel_name=%s", combo.AppVersion, combo.ChannelName), body)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Set the Content-Type header for multipart/form-data.
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+
+		// Set the Authorization header.
+		req.Header.Set("Authorization", "Bearer "+authToken)
+		// Serve the request using the Gin router.
+		router.ServeHTTP(w, req)
+
+		// Check the response status code.
+		assert.Equal(t, http.StatusOK, w.Code)
+		var response map[string]interface{}
+		err = json.Unmarshal(w.Body.Bytes(), &response)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Check that the "token" key exists in the response.
+		id, idExists := response["uploadResult.Uploaded"]
+		assert.True(t, idExists)
+		uploadedAppIDs = append(uploadedAppIDs, id.(string))
+		assert.True(t, idExists)
+		assert.NotEmpty(t, id.(string))
+	}
+}
+func TestSearch(t *testing.T) {
+
+	router := gin.Default()
+	w := httptest.NewRecorder()
+
+	// Define the route for the upload endpoint.
+	handler := handler.NewAppHandler(client, appDB, mongoDatabase)
+	router.GET("/search", func(c *gin.Context) {
+		handler.GetAppByName(c)
+	})
+
+	// Create a POST request for the upload endpoint.
+	req, err := http.NewRequest("GET", "/search?app_name=testapp", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set the Authorization header.
+	req.Header.Set("Authorization", "Bearer "+authToken)
+	// Serve the request using the Gin router.
+	router.ServeHTTP(w, req)
+
+	// Check the response status code.
+	assert.Equal(t, http.StatusOK, w.Code)
+	// Define the expected JSON response as a slice of AppInfo.
+	type AppInfo struct {
+		ID         string `json:"ID"`
+		AppName    string `json:"AppName"`
+		Version    string `json:"Version"`
+		Link       string `json:"Link"`
+		Channel    string `json:"Channel"`
+		Updated_at string `json:"Updated_at"`
+	}
+	type AppResponse struct {
+		Apps []AppInfo `json:"apps"`
+	}
+
+	expected := []AppInfo{
+		{
+			AppName: "testapp",
+			Version: "0.0.1",
+			Channel: "nightly",
+		},
+		{
+			AppName: "testapp",
+			Version: "0.0.2",
+			Channel: "nightly",
+		},
+		{
+			AppName: "testapp",
+			Version: "0.0.3",
+			Channel: "nightly",
+		},
+		{
+			AppName: "testapp",
+			Version: "0.0.4",
+			Channel: "stable",
+		},
+		{
+			AppName: "testapp",
+			Version: "0.0.5",
+			Channel: "stable",
+		},
+	}
+
+	var actual AppResponse
+	err = json.Unmarshal(w.Body.Bytes(), &actual)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Compare the relevant fields (AppName, Version, Channel) for each item in the response.
+	for i, expectedApp := range expected {
+		assert.Equal(t, expectedApp.AppName, actual.Apps[i].AppName)
+		assert.Equal(t, expectedApp.Version, actual.Apps[i].Version)
+		assert.Equal(t, expectedApp.Channel, actual.Apps[i].Channel)
+	}
+}
+
+func TestCheckVersion(t *testing.T) {
+	router := gin.Default()
+	handler := handler.NewAppHandler(client, appDB, mongoDatabase)
+	router.POST("/checkVersion", func(c *gin.Context) {
+		handler.FindLatestVersion(c)
+	})
+	// Define test scenarios.
+	testScenarios := []struct {
+		AppName      string
+		Version      string
+		ChannelName  string
+		ExpectedJSON map[string]interface{}
+		ExpectedCode int
+		TestName     string
+	}{
+		{
+			AppName:     "testapp",
+			Version:     "0.0.1",
+			ChannelName: "nightly",
+			ExpectedJSON: map[string]interface{}{
+				"update_available": true,
+				"update_url":       fmt.Sprintf("%s/testapp/nightly/testapp-0.0.3", s3Endpoint),
+			},
+			ExpectedCode: http.StatusOK,
+			TestName:     "NightlyUpdateAvailable",
+		},
+		{
+			AppName:     "testapp",
+			Version:     "0.0.2",
+			ChannelName: "nightly",
+			ExpectedJSON: map[string]interface{}{
+				"update_available": true,
+				"update_url":       fmt.Sprintf("%s/testapp/nightly/testapp-0.0.3", s3Endpoint),
+			},
+			ExpectedCode: http.StatusOK,
+			TestName:     "NightlyUpdateAvailable",
+		},
+		{
+			AppName:     "testapp",
+			Version:     "0.0.3",
+			ChannelName: "nightly",
+			ExpectedJSON: map[string]interface{}{
+				"update_available": false,
+				"update_url":       fmt.Sprintf("%s/testapp/nightly/testapp-0.0.3", s3Endpoint),
+			},
+			ExpectedCode: http.StatusOK,
+			TestName:     "NightlyUpdateAvailable",
+		},
+		{
+			AppName:     "testapp",
+			Version:     "0.0.4",
+			ChannelName: "stable",
+			ExpectedJSON: map[string]interface{}{
+				"update_available": true,
+				"update_url":       fmt.Sprintf("%s/testapp/stable/testapp-0.0.5", s3Endpoint),
+			},
+			ExpectedCode: http.StatusOK,
+			TestName:     "StableUpdateAvailable",
+		},
+		{
+			AppName:     "testapp",
+			Version:     "0.0.5",
+			ChannelName: "stable",
+			ExpectedJSON: map[string]interface{}{
+				"update_available": false,
+				"update_url":       fmt.Sprintf("%s/testapp/stable/testapp-0.0.5", s3Endpoint),
+			},
+			ExpectedCode: http.StatusOK,
+			TestName:     "StableUpdateAvailable",
+		},
+	}
+
+	for _, scenario := range testScenarios {
+		t.Run(scenario.TestName, func(t *testing.T) {
+			w := httptest.NewRecorder()
+
+			// Create a GET request for checking the version.
+			req, err := http.NewRequest("POST", fmt.Sprintf("/checkVersion?app_name=%s&version=%s&channel_name=%s", scenario.AppName, scenario.Version, scenario.ChannelName), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Set the Authorization header.
+			req.Header.Set("Authorization", "Bearer "+authToken)
+			// Serve the request using the Gin router.
+			router.ServeHTTP(w, req)
+
+			// Check the response status code.
+			assert.Equal(t, scenario.ExpectedCode, w.Code)
+
+			var actual map[string]interface{}
+			err = json.Unmarshal(w.Body.Bytes(), &actual)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Compare the response with the expected values.
+			assert.Equal(t, scenario.ExpectedJSON, actual)
+		})
+	}
+}
+
+func TestMultipleDelete(t *testing.T) {
+
+	router := gin.Default()
+
+	// Define the route for the deleteApp endpoint.
+	handler := handler.NewAppHandler(client, appDB, mongoDatabase)
+	router.DELETE("/deleteApp", func(c *gin.Context) {
+		handler.DeleteApp(c)
+	})
+
+	// Iterate over the uploadedAppIDs and send a DELETE request for each ID.
+	for _, appID := range uploadedAppIDs {
+		w := httptest.NewRecorder()
+
+		req, err := http.NewRequest("DELETE", "/deleteApp?id="+appID, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Set the Authorization header.
+		req.Header.Set("Authorization", "Bearer "+authToken)
+		// Serve the request using the Gin router.
+		router.ServeHTTP(w, req)
+
+		// Check the response status code for each request.
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		expected := `{"deleteAppResult.DeletedCount":1}`
+		assert.Equal(t, expected, w.Body.String())
+	}
+}
+
+func TestDeleteNightlyChannel(t *testing.T) {
+
+	router := gin.Default()
+	w := httptest.NewRecorder()
+
+	// Define the route for the upload endpoint.
+	handler := handler.NewAppHandler(client, appDB, mongoDatabase)
+	router.DELETE("/deleteChannel", func(c *gin.Context) {
+		handler.DeleteChannel(c)
+	})
+
+	// Create a POST request for the upload endpoint.
+	req, err := http.NewRequest("DELETE", "/deleteChannel?id="+idNightlyChannel, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set the Authorization header.
+	req.Header.Set("Authorization", "Bearer "+authToken)
+	// Serve the request using the Gin router.
+	router.ServeHTTP(w, req)
+
+	// Check the response status code.
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	expected := `{"deleteChannelResult.DeletedCount":1}`
+	assert.Equal(t, expected, w.Body.String())
+}
+
+func TestDeleteStableChannel(t *testing.T) {
+
+	router := gin.Default()
+	w := httptest.NewRecorder()
+
+	// Define the route for the upload endpoint.
+	handler := handler.NewAppHandler(client, appDB, mongoDatabase)
+	router.DELETE("/deleteChannel", func(c *gin.Context) {
+		handler.DeleteChannel(c)
+	})
+
+	// Create a POST request for the upload endpoint.
+	req, err := http.NewRequest("DELETE", "/deleteChannel?id="+idStableChannel, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set the Authorization header.
+	req.Header.Set("Authorization", "Bearer "+authToken)
+	// Serve the request using the Gin router.
+	router.ServeHTTP(w, req)
+
+	// Check the response status code.
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	expected := `{"deleteChannelResult.DeletedCount":1}`
+	assert.Equal(t, expected, w.Body.String())
+}


### PR DESCRIPTION
## v1.2.0

### Important Notes

- **Important**: Changed the method of creating an admin user. Now, after creation, the web server starts and operates in normal mode, so it is recommended to use creation in complex with migration.

### Maintenance

- Added `MONGODB_URL_TESTS` to `.env.example`

### Docker
- Added `mongoDB` for testing to `docker compose` configuration.

### Features

- :tada: Implemented e2e tests
    - TestHealthCheck
    - TestLogin
    - TestUploadApp
    - TestUploadDuplicateApp (expected result from api "failed")
    - TestDeleteApp
    - TestChannelCreateNightly
    - TestChannelCreateStable
    - TestUploadAppWithoutChannel (expected result from api "failed")
    - TestMultipleUploadWithChannels
    - TestSearchApp
    - TestCheckVersionLatestVersion
    - TestMultipleDelete
    - TestDeleteNightlyChannel
    - TestDeleteStableChannel